### PR TITLE
Get cross compile going on latest mbusd #7

### DIFF
--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -50,4 +50,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: mbusd
-        path: /home/runner/work/mbusd/mbusd/build/mbusd
+        path: /home/runner/work/mbusd/mbusd/

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -55,4 +55,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: mbusd
-        path: /home/runner/work/mbusd/mbusd/
+        path: /home/runner/work/mbusd/mbusd/build/mbusd

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -47,7 +47,9 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Make
-      run: make
+      run: |
+        cd /home/runner/work/mbusd/mbusd/build
+        make
       
     - name: Upload mbusd binary
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -13,7 +13,7 @@ on:
   
 env:
   BUILD_TYPE: Release
-  xcompile_vars: 'CC=arm-linux-musleabihf-gcc CXX=arm-linux-musleabihf-g++ INCLUDE="-I/usr/arm-linux-musleabihf/include/"'
+  xcompile_vars: 'INCLUDE="-I/usr/arm-linux-musleabihf/include/"'
 
 jobs:
   build-mbusd:
@@ -51,11 +51,3 @@ jobs:
       with:
         name: mbusd
         path: /home/runner/work/mbusd/mbusd/build/mbusd
-      
-    - name: Compile mbusd
-      run: |
-        chmod +x *
-        autoreconf -if
-        ./configure --prefix=/usr/arm-linux-musleabihf/ --host=arm-linux-musleabihf
-        sudo make install ${{ env.xcompile_vars }}
-        ls -alR /usr/arm-linux-musleabihf/

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -4,17 +4,13 @@ on:
   push:
     branches:
       - master
-      - cicd
   pull_request:
     branches:
       - master
-  schedule:
-      - cron: "0 9 * * 0"
   
 env:
   BUILD_TYPE: Release
-  xcompile_vars: 'INCLUDE="-I/usr/arm-linux-musleabihf/include/"'
-
+  
 jobs:
   build-mbusd:
     runs-on: ubuntu-latest
@@ -30,6 +26,7 @@ jobs:
         workflow: musl-artifact.yaml
         workflow_conclusion: success
         name: arm-linux-musleabihf-cross
+        allow_forks: true
         path: .
 
     - name: Copy cross-compiler to usr folder

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up cross-compiler
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v6
       with:
         repo: coolitsystemsinc/cdu-build
         github_token: ${{ secrets.ACTIONS_AUTH }}        
@@ -52,7 +52,7 @@ jobs:
         make
       
     - name: Upload mbusd binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mbusd
         path: ${{github.workspace}}/build/mbusd

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Copy cross-compiler to usr folder
       run: |
         tar -xvf arm-linux-musleabihf-cross.tgz
-        sudo cp -r ./arm-linux-musleabihf-cross/* /usr/
+        sudo cp -r ./arm-linux-musleabihf-cross /usr/
         
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/cmake/arm_linux_gnueabihf.cmake
 
     - name: Build the cmake
       # Build your program with the given configuration
@@ -48,11 +48,11 @@ jobs:
 
     - name: Make
       run: |
-        cd /home/runner/work/mbusd/mbusd/build
+        cd ${{github.workspace}}/build
         make
       
     - name: Upload mbusd binary
       uses: actions/upload-artifact@v3
       with:
         name: mbusd
-        path: /home/runner/work/mbusd/mbusd/build/mbusd
+        path: ${{github.workspace}}/build/mbusd

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -12,6 +12,7 @@ on:
       - cron: "0 9 * * 0"
   
 env:
+  BUILD_TYPE: Release
   xcompile_vars: 'CC=arm-linux-musleabihf-gcc CXX=arm-linux-musleabihf-g++ INCLUDE="-I/usr/arm-linux-musleabihf/include/"'
 
 jobs:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -42,10 +42,13 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Build
+    - name: Build the cmake
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
+    - name: Make
+      run: make
+      
     - name: Upload mbusd binary
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -35,7 +35,22 @@ jobs:
       run: |
         tar -xvf arm-linux-musleabihf-cross.tgz
         sudo cp -r ./arm-linux-musleabihf-cross/* /usr/
+        
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Upload mbusd binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: mbusd
+        path: /home/runner/work/mbusd/mbusd/build/mbusd
+      
     - name: Compile mbusd
       run: |
         chmod +x *
@@ -43,9 +58,3 @@ jobs:
         ./configure --prefix=/usr/arm-linux-musleabihf/ --host=arm-linux-musleabihf
         sudo make install ${{ env.xcompile_vars }}
         ls -alR /usr/arm-linux-musleabihf/
-    
-    - name: Upload mbusd binary
-      uses: actions/upload-artifact@v3
-      with:
-        name: mbusd
-        path: /usr/arm-linux-musleabihf/bin/mbusd

--- a/cmake/arm_linux_gnueabihf.cmake
+++ b/cmake/arm_linux_gnueabihf.cmake
@@ -3,9 +3,9 @@ SET(CMAKE_SYSTEM_NAME Linux)
 SET(CMAKE_SYSTEM_PROCESSOR armhf)
 
 # specify the cross compiler
-SET(CMAKE_C_COMPILER   /usr/bin/arm-linux-gnueabihf-gcc)
-## for c++ support `install g++-arm-linux-gnueabihf`
-#SET(CMAKE_CXX_COMPILER /usr/bin/arm-linux-gnueabihf-g++)
+SET(CMAKE_C_COMPILER   /usr/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc)
+## for c++ support `install g++-arm-linux-musleabihf`
+#SET(CMAKE_CXX_COMPILER /usr/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-g++)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
So previously our build system used Github actions and just `make` to build mbusd into a file we can add to systems. It was cool, it worked, etc.

Issue is that in moving our branch out of the weird zone it used to be in I learned that the main fork is using `cmake` in order to build the file on Github actions.

It looks like previously that was how it worked too but Renee likely had it set up to not use `cmake` and instead just use `make` through doing the configuration files and all prior.

Soooooooooo moving forward I needed to get this going with `cmake` so that any new files/system still works. I've now been able to get the compilation and uploading of the file working but the issue is that the file we get at the end of the building on GA isn't actually able to work on the CDU. Trying to get this CI file to work on a CDU gives me:
![image](https://github.com/user-attachments/assets/54231eee-1986-4310-af11-debe6fce19f0)

I have been able to get the file building and working on CDU by following the Installation instructions in the README.md https://github.com/CoolITSystemsInc/mbusd/blob/d910d9fe74dfa749de666acd2b292fcc3a1870a2/README.md?plain=1#L35-L45

So the step I'm working on is figuring out what is needed to get the CDU build that works onto the CI build so that works. I think this has to do with needing the musl cross compiler to build it. (arm-linux-musleabihf-cross)

https://github.com/CoolITSystemsInc/mbusd/blob/d910d9fe74dfa749de666acd2b292fcc3a1870a2/.github/workflows/build-cc.yml#L24-L32

Still looking into this issue but any help is appreciated!